### PR TITLE
Fix #1 Lien en erreur dans le README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Corrections d'accessibilité sur les composants de [l'organisation ReactJS](https://github.com/reactjs).
 
-[Tutoriel sur la mise en accessibilité](https://disic.github.io/rgaa_bibliotheques_javascript/tutoriels/reactjs.html)
+[Tutoriel sur la mise en accessibilité](https://disic.github.io/rgaa_bibliotheques-javascript/tutoriels/reactjs.html)
 
 ## Installation
 


### PR DESCRIPTION
Correction de l'issue Fix https://github.com/DISIC/rgaa_reactjs/issues/1

> Bonjour,
> 
> Actuellement le lien Tutoriel sur la mise en accessibilité dans le README.md ne fonction pas.
> Je pense qu'il y a une erreur de typo. Il faudrait mettre rgaa_bibliotheques-javascript et non rgaa_bibliotheques_javascript.